### PR TITLE
feat: TECH-7436 - Add Django management command to populate school geopoint fields

### DIFF
--- a/proco/background/utils.py
+++ b/proco/background/utils.py
@@ -8,14 +8,14 @@ def task_on_start(task_id, unique_name, description, check_previous=False):
     try:
         task = BackgroundTask.objects.filter(name=unique_name).first()
         if task:
-            return
+            return None
         else:
             if check_previous and BackgroundTask.objects.filter(
                 description=description,
                 created_at__gte=get_current_datetime_object() - timedelta(hours=12),
                 status=BackgroundTask.STATUSES.running,
             ).exists():
-                return
+                return None
             else:
                 task = BackgroundTask.objects.create(
                     task_id=task_id,
@@ -26,7 +26,7 @@ def task_on_start(task_id, unique_name, description, check_previous=False):
                 )
                 return task
     except:
-        return
+        return None
 
 
 def task_on_complete(task):

--- a/proco/giga_meter/management/commands/populate_school_geopoint_field.py
+++ b/proco/giga_meter/management/commands/populate_school_geopoint_field.py
@@ -1,0 +1,68 @@
+import logging
+
+from django.contrib.gis.geos import Point
+from django.core.management.base import BaseCommand
+
+from proco.giga_meter import tasks as giga_meter_tasks
+from proco.giga_meter.models import GigaMeter_School, GigaMeter_Country
+
+logger = logging.getLogger('gigamaps.' + __name__)
+
+
+def convert_to_point(country_id):
+    school_qry = GigaMeter_School.objects.filter(country_id=country_id)
+
+    for instance in school_qry:
+        if instance.last_school_static:
+            try:
+                latitude = instance.last_school_static.latitude
+                longitude = instance.last_school_static.longitude
+                instance.geopoint = Point(longitude, latitude, srid=4326)
+                instance.save()
+            except (ValueError, IndexError):
+                # Handle cases where lat/long is not in expected format or its NULL
+                pass
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+
+        parser.add_argument(
+            '-country_iso3_format', dest='iso3_format', type=str,
+            required=False,
+            help='Country ISO3 Format Code.'
+        )
+
+        parser.add_argument(
+            '--schedule', action='store_true', dest='schedule_tasks', default=False,
+            help='If provided, it will schedule the task on Celery.'
+        )
+
+
+    def handle(self, **options):
+        logger.info('Started Populate school geopoint field utility.\n')
+
+        country_iso3_format = options.get('iso3_format')
+
+        schedule_tasks = options.get('schedule_tasks')
+        if schedule_tasks:
+            giga_meter_tasks.scheduler_for_populate_school_geopoint_field.delay(country_iso3_format)
+            logger.info('Completed scheduling the Populate school geopoint field successfully.\n')
+            exit(0)
+
+        if country_iso3_format:
+            country = GigaMeter_Country.objects.filter(iso3_format=country_iso3_format).first()
+            logger.info('Country object: {0}'.format(country))
+
+            if not country:
+                logger.error('Country with ISO3 format ({0}) not found in giga-meter db. '
+                             'Hence stopping the load.'.format(country_iso3_format))
+                exit(0)
+            country_ids = [country.id, ]
+        else:
+            country_ids = list(GigaMeter_Country.objects.all().values_list('id', flat=True).order_by('id'))
+
+        for country_id in country_ids:
+            convert_to_point(country_id)
+            logger.info(f'Populate school geopoint field completed for Country Id: {country_id}.')
+
+        logger.info('Completed Populate school geopoint field utility successfully.\n')

--- a/proco/giga_meter/models.py
+++ b/proco/giga_meter/models.py
@@ -1,3 +1,4 @@
+from django.contrib.gis.db.models import PointField
 from django.core.cache import cache
 from django.db import models
 from django.utils.translation import ugettext as _
@@ -38,8 +39,8 @@ class GigaMeter_School(TimeStampedModel):
     name = models.CharField(max_length=1000, default='Name unknown')
     country_code = models.CharField(max_length=32)
     timezone = TimeZoneField(blank=True, null=True)
-    # geopoint = PointField(verbose_name=_('Point'), null=True, blank=True)
-    geopoint = models.CharField(max_length=1000, verbose_name=_('Point'), null=True, blank=True)
+    geopoint = PointField(srid=4326, verbose_name=_('Point'), null=True, blank=True)
+    # geopoint = models.CharField(max_length=1000, verbose_name=_('Point'), null=True, blank=True)
     gps_confidence = models.FloatField(null=True, blank=True)
     altitude = models.PositiveIntegerField(blank=True, default=0)
     address = models.CharField(blank=True, max_length=255)

--- a/proco/giga_meter/tasks.py
+++ b/proco/giga_meter/tasks.py
@@ -6,6 +6,8 @@ import uuid
 from celery import chain
 from celery import current_task
 from django.conf import settings
+from django.contrib.gis.geos import Point
+from django.core.management import call_command
 from django.db.models import Count
 from django.db.utils import DataError
 from requests.exceptions import HTTPError
@@ -155,7 +157,7 @@ def giga_meter_handle_published_school_master_data_row(*args, country_ids=None, 
                             'name': row.school_name,
                             'country_code': row.country.code,
                             # 'timezone': row.timezone,
-                            # 'geopoint': Point(x=row.longitude, y=row.latitude),
+                            'geopoint': Point(x=row.longitude, y=row.latitude),
                             # 'gps_confidence': row.gps_confidence,
                             # 'altitude' : row.altitude,
                             # 'address': row.address,
@@ -354,10 +356,15 @@ def giga_meter_update_static_data(*args, country_iso3_format=None, force_tasks=F
     if force_tasks:
         timestamp_str = format_date(core_utilities.get_current_datetime_object(), frmt='%d%m%Y_%H%M%S')
 
-    task_key = 'giga_meter_update_static_data_status_{current_time}'.format(current_time=timestamp_str)
+    if country_iso3_format:
+        task_key = f'giga_meter_update_static_data_status_{timestamp_str}_country_code_{country_iso3_format}'
+        task_description = f'Giga Meter - Sync Static Data from School Master sources for a country {country_iso3_format}'
+    else:
+        task_key = f'giga_meter_update_static_data_status_{timestamp_str}'
+        task_description = 'Giga Meter - Sync Static Data from School Master sources'
     task_id = current_task.request.id or str(uuid.uuid4())
-    task_instance = background_task_utilities.task_on_start(
-        task_id, task_key, 'Giga Meter - Sync Static Data from School Master sources', check_previous=True)
+
+    task_instance = background_task_utilities.task_on_start(task_id, task_key, task_description, check_previous=True)
 
     if task_instance:
         logger.debug('Not found running job for static data pull handler: {}'.format(task_key))
@@ -410,3 +417,28 @@ def handle_giga_meter_school_master_data_sync(*args):
     else:
         logger.warning('Giga Meter - School Master data synch disabled from config. '
                      'To enable it, please update "GIGA_METER_ENABLE_AUTO_SYNC" configuration.')
+
+
+@app.task(soft_time_limit=4 * 60 * 60, time_limit=4 * 60 * 60)
+def scheduler_for_populate_school_geopoint_field(country_iso3_format):
+    current_datetime = core_utilities.get_current_datetime_object()
+    task_key = 'scheduler_for_populate_school_geopoint_field_for_{code}_country_at_{current_time}'.format(
+        current_time=format_date(current_datetime, frmt='%d%m%Y_%H'),
+        code=country_iso3_format if country_iso3_format else 'all',
+    )
+    task_id = current_task.request.id or str(uuid.uuid4())
+    task_instance = background_task_utilities.task_on_start(task_id, task_key, 'Populate school geopoint field')
+
+    if task_instance:
+        logger.debug('Not found running job for Populate school geopoint field utility handler: {0}'.format(task_key))
+        cmd_args = []
+
+        if country_iso3_format:
+            cmd_args.append('-country_iso3_format={0}'.format(country_iso3_format))
+
+        call_command('populate_school_geopoint_field', *cmd_args)
+        task_instance.info('Completed Populate school geopoint field utility handler.')
+
+        background_task_utilities.task_on_complete(task_instance)
+    else:
+        logger.error('Found running Job with "{0}" name so skipping current iteration'.format(task_key))


### PR DESCRIPTION
feat: TECH-7436 - Add Django management command to populate school geopoint fields

- Implement populate_school_geopoint_field command to convert latitude/longitude 
  coordinates to PostGIS Point geometries for GigaMeter schools
- Support country-specific processing via ISO3 format parameter
- Add Celery task scheduling option for background processing
- Include error handling for invalid or null coordinate data
- Process all countries by default when no country filter is provided

Command usage:
  python manage.py populate_school_geopoint_field [-country_iso3_format ISO3] [--schedule]