### PR TITLE
fix: resolve SQL legend GROUP BY error and null data_source_column_function crash

### DIFF
--- a/proco/accounts/api.py
+++ b/proco/accounts/api.py
@@ -1357,7 +1357,7 @@ class DataLayerInfoViewSet(BaseDataLayerAPIViewSet):
             adm1_metadata."name", adm1_metadata."description_ui_label",
             adm2_metadata."name", adm2_metadata."description_ui_label",
             c."name", adm1_metadata."giga_id_admin", adm2_metadata."giga_id_admin",
-            sds."{col_name}", sws."download_speed_benchmark"
+            sds."{col_name}", sws."id", sws."download_speed_benchmark"
         ORDER BY schools_school."id" ASC
         """
 
@@ -1959,7 +1959,7 @@ class DataLayerInfoViewSet(BaseDataLayerAPIViewSet):
                             #     positive_speeds[str(info_panel_school['id'])]) > 0 else 0)
 
                             info_panel_school['live_avg'] = self.get_live_avg(
-                                parameter_col_function.get('name', 'avg'),
+                                (parameter_col_function or {}).get('name', 'avg'),
                                 positive_speeds[str(info_panel_school['id'])]
                             )
                             info_panel_school['graph_data'] = graph_data[str(info_panel_school['id'])]
@@ -2014,7 +2014,7 @@ class DataLayerInfoViewSet(BaseDataLayerAPIViewSet):
 
                     graph_data, positive_speeds = self.generate_graph_data()
                     live_avg = self.get_live_avg(
-                        parameter_col_function.get('name', 'avg'),
+                        (parameter_col_function or {}).get('name', 'avg'),
                         positive_speeds
                     )
 


### PR DESCRIPTION
## Summary

- **GROUP BY fix**: Added `sws."id"` to the GROUP BY in `get_school_view_info_query()` so that any `sws` column (e.g. `num_students`) can be referenced in SQL legend `case_conditions` without a PostgreSQL aggregation error. Since `sws` is 1:1 with each school via `last_weekly_status_id`, this does not change query semantics or performance.
- **Null guard (x2)**: Fixed `AttributeError: 'NoneType' object has no attribute 'get'` at two call sites where `parameter_col_function.get('name', 'avg')` was called without a null check. `data_source_column_function` is a nullable field and existing DB rows have `None`. Changed to `(parameter_col_function or {}).get('name', 'avg')` to fall back safely to `'avg'`.

## Test plan

- [ ] Hit `/api/accounts/layers/{pk}/info/` at country level (no `school_id__in`) for a layer where `data_source_column_function` is null — should no longer 500
- [ ] Hit `/api/accounts/layers/{pk}/info/?school_id__in=...` for a school in a country with SQL-based national legend using `sws."num_students"` — should no longer return GROUP BY error
- [ ] Verify existing countries with `download_speed_benchmark`-based SQL legends still work correctly