### PR TITLE
Enable prometheus_client multiprocess mode for gunicorn (exact metrics)

### DIFF
--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,0 +1,43 @@
+"""
+Gunicorn configuration.
+
+Enables prometheus_client multiprocess mode so that the Django Prometheus
+metrics (request counts, latency histograms, response sizes, ...) are
+aggregated across every gunicorn worker into a single registry.
+
+Without this, each sync worker keeps its own in-memory counters and a scrape
+of ``/metrics`` is answered by whichever worker happens to handle it. Prometheus
+then sees a different worker's counters on each scrape, the series is
+non-monotonic, and ``rate()``/``increase()`` treat the jumps as counter resets
+- making the numbers on the Grafana dashboard approximate. With multiprocess
+mode the workers share metric files in ``PROMETHEUS_MULTIPROC_DIR`` and the
+``/metrics`` endpoint aggregates them, so counters/histograms are exact.
+
+This module is imported by the gunicorn arbiter at startup (before workers are
+forked), so setting the environment variable here propagates to every worker.
+"""
+
+import os
+import shutil
+
+# Shared directory the workers write their metric files to. Respect an existing
+# value if the platform already sets one; otherwise fall back to a per-container
+# tmp path. It must be local to the container and cleared on every boot.
+prometheus_multiproc_dir = os.environ.setdefault(
+    'PROMETHEUS_MULTIPROC_DIR', '/tmp/prometheus_multiproc',
+)
+
+# Start each boot from a clean directory - stale files left over from a previous
+# run would corrupt the aggregated values.
+shutil.rmtree(prometheus_multiproc_dir, ignore_errors=True)
+os.makedirs(prometheus_multiproc_dir, exist_ok=True)
+
+
+def child_exit(server, worker):
+    """Reap a dead worker's metric files so its samples aren't double counted.
+
+    Called by the gunicorn arbiter whenever a worker exits (crash, reload, or a
+    ``--timeout`` kill). Required for correct counters in multiprocess mode.
+    """
+    from prometheus_client import multiprocess
+    multiprocess.mark_process_dead(worker.pid)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   backend:
     container_name: proco_prod_backend
     image: rttest/project-connect-api:prod
-    command: bash -c "sleep 10 && /code/scripts/wait-for-it.sh db:5432 && pipenv run python manage.py migrate && pipenv run gunicorn config.wsgi:application -b 0.0.0.0:8000 -w 4 --timeout=3200"
+    command: bash -c "sleep 10 && /code/scripts/wait-for-it.sh db:5432 && pipenv run python manage.py migrate && pipenv run gunicorn config.wsgi:application -c /code/config/gunicorn.py -b 0.0.0.0:8000 -w 4 --timeout=3200"
     ports:
       - "8000:8000"
     environment:

--- a/web-worker.sh
+++ b/web-worker.sh
@@ -13,7 +13,7 @@ service ssh start
 
 # pipenv run python manage.py migrate
 pipenv run python manage.py collectstatic --noinput
-pipenv run gunicorn config.wsgi:application -b 0.0.0.0:8000 -w 8 --timeout=300
+pipenv run gunicorn config.wsgi:application -c /code/config/gunicorn.py -b 0.0.0.0:8000 -w 8 --timeout=300
 
 
 # pipenv run python manage.py load_api_data --api-file /code/proco/core/resources/all_apis.tsv


### PR DESCRIPTION
## Why

The Django Prometheus HTTP metrics that feed the **Giga Maps Backend Django** Grafana dashboard are currently collected **per worker**. Gunicorn runs 8 sync workers (`web-worker.sh`), each keeping its own in-memory `prometheus_client` registry, and a `/metrics` scrape is answered by whichever single worker handles it. Prometheus therefore sees a different worker's counters on each scrape → the series is non-monotonic → `rate()`/`increase()` interpret the jumps as counter resets.

**Effect:** the request/latency/response counts on the dashboard (e.g. the per-view request rates) are approximate/undercounted. Latency *percentiles* are largely fine (histogram buckets still aggregate), but raw counts are not exact.

## What this does

Enables `prometheus_client` **multiprocess mode** so all workers share one metric store and `/metrics` aggregates them:

- **`config/gunicorn.py`** (new): sets `PROMETHEUS_MULTIPROC_DIR` (defaults to `/tmp/prometheus_multiproc`, respects an existing value), clears it on every boot, and registers a `child_exit` hook that calls `multiprocess.mark_process_dead(worker.pid)` so a dead worker's files aren't double-counted. The module is imported by the gunicorn arbiter before workers fork, so the env var propagates to every worker.
- **`web-worker.sh`** / **`docker/docker-compose.yml`**: pass `-c /code/config/gunicorn.py` to gunicorn.

No Django settings change is needed — `django-prometheus` (2.2.0) auto-detects `PROMETHEUS_MULTIPROC_DIR` and serves an aggregated `MultiProcessCollector` registry from `/metrics`.

## Scope / notes

- Deliberately **does not** change worker count, worker class, or timeouts — metrics accuracy only.
- In multiprocess mode the default `process_*` / python-GC metrics are not exported. The dashboard uses only `django_http_*` series, so no panels are affected.
- The multiproc dir is per-container and cleared on boot; no shared/persistent volume required.
- Separately, the empty **Database Queries** and **Cache Hit Ratio** panels are a *different* gap (uninstrumented DB/cache backends) and are intentionally out of scope here.

## Verification

Local: `config/gunicorn.py` byte-compiles, and running its setup logic confirms it sets the env var, clears stale files, creates the dir, and exposes a callable `child_exit`.

On dev after deploy:
1. `curl -s <host>/metrics | grep -c '^django_http_requests_total'` returns aggregated samples; values increase monotonically across repeated scrapes (no resets).
2. Confirm multiprocess mode is active: `process_resident_memory_bytes` and `python_gc_*` are **absent** from `/metrics` (expected in multiproc mode).
3. On the Grafana dashboard, the per-view request-rate sawtooth/drop-to-zero artifacts flatten out and counts rise to reflect all 8 workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)