### PR TITLE
Instrument DB connections for Prometheus (flag-gated)

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -26,6 +26,27 @@ DATABASES = {
     GIGA_METER_DB_KEY: env.db_url(var='GIGA_METER_DATABASE_URL'),
 }
 
+# Prometheus DB instrumentation
+# --------------------------------------------------------------------------
+# Wrap each DB connection with django_prometheus so query counts and durations
+# are exported per alias (django_db_execute_total, django_db_query_duration_seconds).
+# The wrappers are thin subclasses of the underlying Django backend: they only
+# time/count queries and never change SQL, connections, or data. Each engine is
+# mapped to its instrumented equivalent so a non-PostGIS connection (e.g. the
+# giga_meter DB) keeps the correct backend. Flag-gated so it can be turned off via
+# env (ENABLED_DB_METRICS=False) without a code change if a wrapper misbehaves.
+ENABLED_DB_METRICS = env.bool('ENABLED_DB_METRICS', default=ENABLED_BACKEND_PROMETHEUS_METRICS)
+if ENABLED_DB_METRICS:
+    _INSTRUMENTED_DB_ENGINES = {
+        'django.contrib.gis.db.backends.postgis': 'django_prometheus.db.backends.postgis',
+        'django.db.backends.postgresql': 'django_prometheus.db.backends.postgresql',
+        'django.db.backends.postgresql_psycopg2': 'django_prometheus.db.backends.postgresql',
+    }
+    for _db_settings in DATABASES.values():
+        _db_settings['ENGINE'] = _INSTRUMENTED_DB_ENGINES.get(
+            _db_settings.get('ENGINE'), _db_settings.get('ENGINE'),
+        )
+
 # Template
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

The **Database Total Queries** and **Database Query Duration** panels on the Grafana dashboard are empty because the DB connections aren't instrumented (engine is `postgis` / `postgresql`, not the `django_prometheus` wrappers). That leaves us blind below the HTTP layer — we can see an endpoint is slow but not whether it's DB-bound. This adds that visibility, which is the most useful missing signal for the ongoing map-data-layer / tail-latency work.

## What

Maps each DB connection's engine to its `django_prometheus` equivalent:
- `django.contrib.gis.db.backends.postgis` → `django_prometheus.db.backends.postgis`
- `django.db.backends.postgresql` → `django_prometheus.db.backends.postgresql`

Applied to all three aliases (`default`, `read_only_database`, `giga_meter`). Exports:
- `django_db_execute_total` — query count per alias
- `django_db_query_duration_seconds` — query duration histogram per alias
- `django_db_new_connections_total`, `django_db_errors_total`

Because the wrappers instrument the Django connection cursor, even the raw MVT tile SQL (`connections[READ_ONLY_DB_KEY].cursor()`) is captured.

## Why it's low-risk

- **Thin subclasses of the existing backend** — they only time/count queries; they never change SQL, connection params, transactions, or data. No data-corruption path.
- **Engine-preserving map** — each engine maps to its *matching* instrumented backend, so a non-PostGIS connection (e.g. `giga_meter`) is not forced onto the postgis backend, and GIS support is preserved on the proco DBs. Unknown engines are left untouched.
- **Version-matched** — Django `>=2.2,<3` with `django-prometheus==2.2.0` are the same era; the DB wrappers support this Django version.
- **Low cardinality** — labels are alias/vendor/query-type, not SQL text.
- **Negligible overhead** — one timer + histogram observe per query.
- **Preserves connection OPTIONS** — the read-replica's `statement_timeout` is untouched.

Worst case is a **boot-time** init failure (loud, immediate, caught in staging), not a subtle production regression — and it's reversible.

## Kill switch

Gated behind **`ENABLED_DB_METRICS`** (defaults to `ENABLED_BACKEND_PROMETHEUS_METRICS`). Set `ENABLED_DB_METRICS=False` in env to disable instantly without a code change/redeploy.

## Verification

- `config/settings/prod.py` byte-compiles.
- On staging after deploy:
  1. `curl -s <host>/metrics | grep django_db_` returns series for `default`, `read_only_database`, `giga_meter`.
  2. App boots and serves normally (spatial/map endpoints work — GIS preserved).
  3. The Grafana "Database" panels populate.
- Note: for fully accurate multi-worker aggregation, this pairs with the multiprocess-metrics change (#243); the counters/histograms here aggregate cleanly under that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)