### PR TITLE
perf(connection_statistics): add composite index for daily status loo…

### DIFF
--- a/proco/connection_statistics/migrations/0071_add_sds_school_date_source_index.py
+++ b/proco/connection_statistics/migrations/0071_add_sds_school_date_source_index.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    atomic = False
+
+    dependencies = [
+        ('connection_statistics', '0070_auto_20260403_0547'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=(
+                'CREATE INDEX CONCURRENTLY IF NOT EXISTS sds_school_date_source_idx '
+                'ON connection_statistics_schooldailystatus (school_id, date, live_data_source) '
+                'WHERE deleted IS NULL;'
+            ),
+            reverse_sql='DROP INDEX CONCURRENTLY IF EXISTS sds_school_date_source_idx;',
+        ),
+    ]


### PR DESCRIPTION
…kups

Add sds_school_date_source_idx (school_id, date, live_data_source) WHERE deleted IS NULL on connection_statistics_schooldailystatus.

The data-layer info and MVT map endpoints aggregate daily status per school via school_id + date range + live_data_source. Without a school_id-leading composite index, Postgres falls back to the plain school_id index and scans all of a school's history per lookup (tens of millions of buffer hits), making these endpoints ~25s (info) and ~13s (map) on prod. The existing schooldailystatus_unique_without_deleted index leads with date, so it cannot serve these per-school lookups.

Created CONCURRENTLY (atomic = False) since the table is large and actively written; IF NOT EXISTS keeps it idempotent where the index already exists.