### PR TITLE
Make metrics endpoint resilient and guard get_git_hash; add tests

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+# Make metrics endpoint resilient and guard get_git_hash; add tests
+
+Summary:
+- Adds robust error handling and a timeout to the Flask /metrics endpoint (returns 503 when upstream is unavailable and preserves Content-Type).
+- Makes config.utils.get_git_hash safe when gitpython is missing or not in a git repo (returns 'unknown' instead of raising).
+- Adds pytest tests for both code paths.
+
+Why:
+Prevents health-check hangs and import-time crashes in environments without git metadata or gitpython.

--- a/config/utils.py
+++ b/config/utils.py
@@ -1,7 +1,8 @@
-import git
-
-
 def get_git_hash():
-    repo = git.Repo(search_parent_directories=True)
-    sha = repo.head.commit.hexsha
-    return repo.git.rev_parse(sha, short=4)
+    try:
+        import git
+        repo = git.Repo(search_parent_directories=True)
+        sha = repo.head.commit.hexsha
+        return repo.git.rev_parse(sha, short=4)
+    except Exception:
+        return 'unknown'

--- a/hello.py
+++ b/hello.py
@@ -1,7 +1,7 @@
 import os
 import requests
 
-from flask import Flask
+from flask import Flask, Response
 
 app = Flask(__name__)
 
@@ -10,7 +10,15 @@ app = Flask(__name__)
 def hello_world():
     return 'Hello, World!'
 
-@app.route("/metrics")
+@app.route('/metrics')
 def metrics():
-    response = requests.get('http://localhost:{port}/metrics'.format(port=os.environ.get('FLOWER_PORT', 6543)))
-    return response.text
+    port = os.environ.get('FLOWER_PORT', '6543')
+    url = f'http://localhost:{port}/metrics'
+    try:
+        resp = requests.get(url, timeout=2)
+        resp.raise_for_status()
+    except requests.RequestException:
+        return 'Metrics unavailable', 503
+
+    content_type = resp.headers.get('Content-Type', 'text/plain')
+    return Response(resp.text, content_type=content_type)

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,0 +1,31 @@
+import requests
+from hello import app
+
+
+class DummyResponse:
+    def __init__(self, text='metrics', content_type='text/plain'):
+        self.text = text
+        self.headers = {'Content-Type': content_type}
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+
+def test_metrics_success(monkeypatch):
+    monkeypatch.setattr('requests.get', lambda url, timeout: DummyResponse())
+    client = app.test_client()
+    res = client.get('/metrics')
+    assert res.status_code == 200
+    assert b'metrics' in res.data
+
+
+def test_metrics_unavailable(monkeypatch):
+    def raise_exc(url, timeout):
+        raise requests.RequestException
+
+    monkeypatch.setattr('requests.get', raise_exc)
+    client = app.test_client()
+    res = client.get('/metrics')
+    assert res.status_code == 503
+    assert b'Metrics unavailable' in res.data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+import sys
+import types
+
+from config.utils import get_git_hash
+
+
+def test_get_git_hash_no_git(monkeypatch):
+    # make importing 'git' raise ImportError
+    real_import = __import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == 'git':
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr('builtins.__import__', fake_import)
+    assert get_git_hash() == 'unknown'
+
+
+def test_get_git_hash_with_fake_git(monkeypatch):
+    # inject a fake git module with a Repo that returns a known sha
+    mod = types.ModuleType('git')
+
+    class DummyRepo:
+        def __init__(self, search_parent_directories=True):
+            self.head = types.SimpleNamespace(commit=types.SimpleNamespace(hexsha='abcd1234'))
+
+            class GitObj:
+                def rev_parse(self, sha, short=4):
+                    return sha[:short]
+
+            self.git = GitObj()
+
+    mod.Repo = DummyRepo
+    monkeypatch.setitem(sys.modules, 'git', mod)
+
+    assert get_git_hash() == 'abcd'


### PR DESCRIPTION
Adds robust error handling and a timeout to the Flask /metrics endpoint (returns 503 when upstream is unavailable and preserves Content-Type).
Makes config.utils.get_git_hash safe when gitpython is missing or not in a git repo (returns 'unknown' instead of raising).
Adds pytest tests for both code paths.
Rationale: prevents health-check hangs and import-time crashes in environments without git metadata or gitpython.