### PR TITLE
feature: add data source health field

### DIFF
--- a/proco/locations/migrations/0023_added_health_data_source_field_on_country.py
+++ b/proco/locations/migrations/0023_added_health_data_source_field_on_country.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0022_added_disclaimer_field_on_country'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='country',
+            name='health_data_source',
+            field=models.TextField(blank=True, default='', max_length=500),
+        ),
+    ]

--- a/proco/locations/models.py
+++ b/proco/locations/models.py
@@ -41,6 +41,7 @@ class Country(GeometryMixin, TimeStampedModel):
     description = models.TextField(max_length=1000, blank=True, default='')
     data_source = models.TextField(max_length=500, blank=True, default='')
     data_source_description = models.TextField(max_length=500, blank=True, default='')
+    health_data_source = models.TextField(max_length=500, blank=True, default='')
 
     date_of_join = models.DateField(null=True, blank=True, default=None)
     date_schools_mapped = models.DateField(null=True, blank=True, default=None)

--- a/proco/locations/serializers.py
+++ b/proco/locations/serializers.py
@@ -89,6 +89,7 @@ class BaseCountrySerializer(FlexFieldsModelSerializer):
             'description',
             'data_source',
             'data_source_description',
+            'health_data_source',
             'date_schools_mapped',
             'admin_metadata',
             'benchmark_metadata',


### PR DESCRIPTION
Add health data source field into country admin panel

This field will be input from country admin panel, in a newly created health data source field. Different from school data source. 