### PR TITLE
Add local Prometheus and Grafana observability setup

### DIFF
--- a/docker/docker-compose.observability.local.yml
+++ b/docker/docker-compose.observability.local.yml
@@ -1,0 +1,25 @@
+services:
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    volumes:
+      - "./prometheus.local.yml:/etc/prometheus/prometheus.yml:ro"
+      - "prometheus_local_data:/prometheus"
+    depends_on:
+      - backend
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - "grafana_local_data:/var/lib/grafana"
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus_local_data:
+  grafana_local_data:

--- a/docker/prometheus.local.yml
+++ b/docker/prometheus.local.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: giga-maps-backend
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - backend:8000


### PR DESCRIPTION
## Summary

Adds a local Prometheus and Grafana setup for the Giga Maps backend.

## Changes

- Adds a Prometheus scrape configuration for the Django `/metrics` endpoint.
- Adds Prometheus and Grafana services through a local Docker Compose override.
- Persists local Prometheus and Grafana data using named Docker volumes.
- Allows Grafana to access Prometheus using `http://prometheus:9090`.

## Running locally

```bash
docker compose \
  -f docker/docker-compose.local.yml \
  -f docker/docker-compose.observability.local.yml \
  up -d